### PR TITLE
Added compatibility with TSR-700

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,7 +93,7 @@ function makelayout(settings) {
     };
 
     if (!settings.zone_input_list[key]["input_list"].find(i1 => i1.value === settings.input)) {
-        settings.input = yamaha.default_input;
+        settings.input = settings.zone_input_list[key]["input_list"][0].value;
     }
     settings.inputName = (settings.zone_input_list[key]["input_list"].find(i1 => i1.value === settings.input)).title;
 
@@ -190,7 +190,7 @@ async function get_yamaha_props() {
                     let input_list = [];
                     for (let key in inputs) {
                         // console.log(key + ": " + inputs[key]); //(inputs[key].substr(0, 2) = 'av') || (inputs[key].substr(0, 5) = 'audio' ) || 
-                        if (inputs[key].includes('av') || inputs[key].includes('audio') || inputs[key].includes('airplay')  ) {
+                        if (inputs[key].includes('av') || inputs[key].includes('audio') || inputs[key].includes('airplay') || inputs[key].includes('hdmi')) {
                                 input_list.push({
                                     "title": inputNames.find(inputName => inputName.id === inputs[key]).text,
                                     "value": inputs[key],


### PR DESCRIPTION
This patch addresses the issue when opening Settings dialog crashes the extension for Yamaha TSR-700. This receiver does not have any 'av*' inputs, so that setting the default one ends up with an exception.

It is also possible to link Roon server and Yamaha receiver via HDMI where HDMI is a digital audio source  

- Change default input from 'av1' to first available
- HDMI inputs added to the allowed inputs filter